### PR TITLE
Fix clang warnings with -Weverything

### DIFF
--- a/source/fleet_provisioning.c
+++ b/source/fleet_provisioning.c
@@ -80,7 +80,7 @@ static uint16_t getRegisterThingTopicLength( uint16_t templateNameLength,
  * The caller is responsible for assuring that there is enough space remaining
  * in the buffer to write the given string.
  *
- * @param[in, out] pBufferCursor Pointer to the remaining buffer.
+ * @param[in,out] pBufferCursor Pointer to the remaining buffer.
  * @param[in] fragment The piece of the topic string to write.
  * @param[in] length The length of @p fragment.
  */
@@ -183,8 +183,8 @@ static FleetProvisioningTopic_t parseRegisterThingTopic( const char * pTopic,
  * moves the remaining buffer pointer past the matched section and updates the
  * remaining length.
  *
- * @param[in, out] pBufferCursor Pointer to the remaining portion of the buffer.
- * @param[in, out] pRemainingLength The remaining length of the buffer.
+ * @param[in,out] pBufferCursor Pointer to the remaining portion of the buffer.
+ * @param[in,out] pRemainingLength The remaining length of the buffer.
  * @param[in] matchString The string to match against.
  * @param[in] matchLength The length of @p matchString.
  *
@@ -209,8 +209,8 @@ static FleetProvisioningStatus_t consumeIfMatch( const char ** pBufferCursor,
  * The second topic is not a valid Fleet Provisioning topic and the matching
  * will fail when we try to match the bridge part.
  *
- * @param[in, out] pTopicCursor Pointer to the remaining topic string.
- * @param[in, out] pRemainingLength Pointer to the length of the remaining topic string.
+ * @param[in,out] pTopicCursor Pointer to the remaining topic string.
+ * @param[in,out] pRemainingLength Pointer to the length of the remaining topic string.
  *
  * @return FleetProvisioningSuccess if a valid template name is skipped over;
  * FleetProvisioningNoMatch otherwise.

--- a/test/unit-test/fleet_provisioning_utest.c
+++ b/test/unit-test/fleet_provisioning_utest.c
@@ -271,7 +271,7 @@ void test_FleetProvisioning_GetRegisterThingTopic_BadParams( void )
     /* Invalid Format. */
     ret = FleetProvisioning_GetRegisterThingTopic( &( testTopicBuffer[ TEST_TOPIC_BUFFER_PREFIX_GUARD_LENGTH ] ),
                                                    TEST_TOPIC_BUFFER_WRITABLE_LENGTH,
-                                                   FleetProvisioningCbor + 1,
+                                                   ( FleetProvisioningFormat_t ) ( FleetProvisioningCbor + 1 ),
                                                    FleetProvisioningPublish,
                                                    TEST_TEMPLATE_NAME,
                                                    TEST_TEMPLATE_NAME_LENGTH,
@@ -285,7 +285,7 @@ void test_FleetProvisioning_GetRegisterThingTopic_BadParams( void )
     ret = FleetProvisioning_GetRegisterThingTopic( &( testTopicBuffer[ TEST_TOPIC_BUFFER_PREFIX_GUARD_LENGTH ] ),
                                                    TEST_TOPIC_BUFFER_WRITABLE_LENGTH,
                                                    FleetProvisioningCbor,
-                                                   FleetProvisioningRejected + 1,
+                                                   ( FleetProvisioningApiTopics_t ) ( FleetProvisioningRejected + 1 ),
                                                    TEST_TEMPLATE_NAME,
                                                    TEST_TEMPLATE_NAME_LENGTH,
                                                    &( topicLength ) );

--- a/test/unit-test/fleet_provisioning_utest.c
+++ b/test/unit-test/fleet_provisioning_utest.c
@@ -156,6 +156,44 @@ int suiteTearDown( int numFailures )
 }
 /*-----------------------------------------------------------*/
 
+/* Prototypes for test functions. */
+void test_RegisterThing_MacrosString( void );
+void test_RegisterThing_MacrosLength( void );
+void test_FleetProvisioning_GetRegisterThingTopic_BadParams( void );
+void test_FleetProvisioning_GetRegisterThingTopic_BufferTooSmall( void );
+void test_FleetProvisioning_GetRegisterThingTopic_JsonPublishHappyPath( void );
+void test_FleetProvisioning_GetRegisterThingTopic_JsonAcceptedHappyPath( void );
+void test_FleetProvisioning_GetRegisterThingTopic_JsonRejectedHappyPath( void );
+void test_FleetProvisioning_GetRegisterThingTopic_CborPublishHappyPath( void );
+void test_FleetProvisioning_GetRegisterThingTopic_CborAcceptedHappyPath( void );
+void test_FleetProvisioning_GetRegisterThingTopic_CborRejectedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_BadParams( void );
+void test_FleetProvisioning_MatchTopic_InvalidFormat( void );
+void test_FleetProvisioning_MatchTopic_ZeroLengthTemplateName( void );
+void test_FleetProvisioning_MatchTopic_RegisterThingMissingSuffix( void );
+void test_FleetProvisioning_MatchTopic_InvalidSuffix( void );
+void test_FleetProvisioning_MatchTopic_ExtraData( void );
+void test_FleetProvisioning_MatchTopic_CreateCertificateFromCsrJsonPublishHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateCertificateFromCsrJsonAcceptedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateCertificateFromCsrJsonRejectedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateCertificateFromCsrCborPublishHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateCertificateFromCsrCborAcceptedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateCertificateFromCsrCborRejectedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateKeysAndCertificateJsonPublishHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateKeysAndCertificateJsonAcceptedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateKeysAndCertificateJsonRejectedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateKeysAndCertificateCborPublishHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateKeysAndCertificateCborAcceptedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_CreateKeysAndCertificateCborRejectedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_RegisterThingJsonPublishHappyPath( void );
+void test_FleetProvisioning_MatchTopic_RegisterThingJsonAcceptedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_RegisterThingJsonRejectedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_RegisterThingCborPublishHappyPath( void );
+void test_FleetProvisioning_MatchTopic_RegisterThingCborAcceptedHappyPath( void );
+void test_FleetProvisioning_MatchTopic_RegisterThingCborRejectedHappyPath( void );
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Test that macros generate expected strings.
  */


### PR DESCRIPTION
Fixes all clang warnings in c/h files in this repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
