### PR TITLE
Fix logging macro invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,18 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
         with:
           path: ./build/coverage.info
+  default-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DFLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG'
+          make -C build/ all
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
         with:
           path: ./build/coverage.info
-  default-config:
+  build-with-default-config:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo

--- a/source/fleet_provisioning.c
+++ b/source/fleet_provisioning.c
@@ -295,15 +295,14 @@ static FleetProvisioningStatus_t GetRegisterThingTopicCheckParams( const char * 
     {
         ret = FleetProvisioningBadParameter;
 
-        LogError( ( "Invalid input parameter. pTopicBuffer: %p, bufferLength: %u, format: %d, "
-                    "topic: %d, pTemplateName: %p, templateNameLength: %u, pOutLength: %p.",
-                    ( void * ) pTopicBuffer,
-                    ( unsigned int ) bufferLength,
+        LogError( ( "Invalid input parameter. pTopicBuffer: %p, format: %d, topic: %d,"
+                    " pTemplateName: %p, templateNameLength: %u, pOutLength: %p.",
+                    ( const void * ) pTopicBuffer,
                     ( int ) format,
                     ( int ) topic,
-                    ( void * ) pTemplateName,
+                    ( const void * ) pTemplateName,
                     ( unsigned int ) templateNameLength,
-                    ( void * ) pOutLength ) );
+                    ( const void * ) pOutLength ) );
     }
     else
     {
@@ -737,7 +736,7 @@ FleetProvisioningStatus_t FleetProvisioning_MatchTopic( const char * pTopic,
     {
         ret = FleetProvisioningBadParameter;
         LogError( ( "Invalid input parameter. pTopic: %p, pOutApi: %p.",
-                    ( void * ) pTopic,
+                    ( const void * ) pTopic,
                     ( void * ) pOutApi ) );
     }
     else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,11 +40,10 @@ include( ${MODULE_ROOT_DIR}/fleetprovisioningFilePaths.cmake )
 add_library( coverity_analysis
              ${FLEET_PROVISIONING_SOURCES} )
 
-# Build Fleet Provisioning library without requiring config file.
-target_compile_definitions( coverity_analysis PUBLIC FLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG=1 )
-
-# Fleet Provisioning public include path.
-target_include_directories( coverity_analysis PUBLIC ${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS} )
+# Fleet Provisioning public include path and test config file.
+target_include_directories( coverity_analysis PUBLIC
+                            ${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS}
+                            "${CMAKE_CURRENT_LIST_DIR}/include" )
 
 #  ============================  Test Configuration ============================
 

--- a/test/cbmc/proofs/Makefile-project-defines
+++ b/test/cbmc/proofs/Makefile-project-defines
@@ -27,9 +27,10 @@ COMPILE_FLAGS += -fPIC -std=gnu90
 #
 INCLUDES += -I$(CBMC_ROOT)/include
 INCLUDES += -I$(SRCDIR)/source/include
+INCLUDES += -I$(SRCDIR)/test/include
 
 # Preprocessor definitions -D...
-DEFINES += -DFLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG
+# DEFINES =
 
 # Path to arpa executable
 # ARPA =

--- a/test/include/fleet_provisioning_config.h
+++ b/test/include/fleet_provisioning_config.h
@@ -30,12 +30,12 @@
 
 #include <stdio.h>
 
-#define LogError( message )    printf( "Error: " ); printf message; printf( "\n" );
+#define LogError( message )    printf( "Error: " ); printf message; printf( "\n" )
 
-#define LogWarn( message )     printf( "Warn: " ); printf message; printf( "\n" );
+#define LogWarn( message )     printf( "Warn: " ); printf message; printf( "\n" )
 
-#define LogInfo( message )     printf( "Info: " ); printf message; printf( "\n" );
+#define LogInfo( message )     printf( "Info: " ); printf message; printf( "\n" )
 
-#define LogDebug( message )    printf( "Debug: " ); printf message; printf( "\n" );
+#define LogDebug( message )    printf( "Debug: " ); printf message; printf( "\n" )
 
 #endif /* FLEET_PROVISIONING_CONFIG_H_ */

--- a/test/include/fleet_provisioning_config.h
+++ b/test/include/fleet_provisioning_config.h
@@ -1,0 +1,41 @@
+/*
+ * AWS IoT Fleet Provisioning Client v1.0.0
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file fleet_provisioning_config.h
+ * @brief Config values for testing the AWS IoT Fleet Provisioning Client Library.
+ */
+
+#ifndef FLEET_PROVISIONING_CONFIG_H_
+#define FLEET_PROVISIONING_CONFIG_H_
+
+#include <stdio.h>
+
+#define LogError( message )    printf message
+
+#define LogWarn( message )     printf message
+
+#define LogInfo( message )     printf message
+
+#define LogDebug( message )    printf message
+
+#endif /* FLEET_PROVISIONING_CONFIG_H_ */

--- a/test/include/fleet_provisioning_config.h
+++ b/test/include/fleet_provisioning_config.h
@@ -30,12 +30,12 @@
 
 #include <stdio.h>
 
-#define LogError( message )    printf message
+#define LogError( message )    printf( "Error: " ); printf message
 
-#define LogWarn( message )     printf message
+#define LogWarn( message )     printf( "Warn: " ); printf message
 
-#define LogInfo( message )     printf message
+#define LogInfo( message )     printf( "Info: " ); printf message
 
-#define LogDebug( message )    printf message
+#define LogDebug( message )    printf( "Debug: " ); printf message
 
 #endif /* FLEET_PROVISIONING_CONFIG_H_ */

--- a/test/include/fleet_provisioning_config.h
+++ b/test/include/fleet_provisioning_config.h
@@ -30,12 +30,12 @@
 
 #include <stdio.h>
 
-#define LogError( message )    printf( "Error: " ); printf message
+#define LogError( message )    printf( "Error: " ); printf message; printf ( "\n" );
 
-#define LogWarn( message )     printf( "Warn: " ); printf message
+#define LogWarn( message )     printf( "Warn: " ); printf message; printf ( "\n" );
 
-#define LogInfo( message )     printf( "Info: " ); printf message
+#define LogInfo( message )     printf( "Info: " ); printf message; printf ( "\n" );
 
-#define LogDebug( message )    printf( "Debug: " ); printf message
+#define LogDebug( message )    printf( "Debug: " ); printf message; printf ( "\n" );
 
 #endif /* FLEET_PROVISIONING_CONFIG_H_ */

--- a/test/include/fleet_provisioning_config.h
+++ b/test/include/fleet_provisioning_config.h
@@ -30,12 +30,12 @@
 
 #include <stdio.h>
 
-#define LogError( message )    printf( "Error: " ); printf message; printf ( "\n" );
+#define LogError( message )    printf( "Error: " ); printf message; printf( "\n" );
 
-#define LogWarn( message )     printf( "Warn: " ); printf message; printf ( "\n" );
+#define LogWarn( message )     printf( "Warn: " ); printf message; printf( "\n" );
 
-#define LogInfo( message )     printf( "Info: " ); printf message; printf ( "\n" );
+#define LogInfo( message )     printf( "Info: " ); printf message; printf( "\n" );
 
-#define LogDebug( message )    printf( "Debug: " ); printf message; printf ( "\n" );
+#define LogDebug( message )    printf( "Debug: " ); printf message; printf( "\n" );
 
 #endif /* FLEET_PROVISIONING_CONFIG_H_ */

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -13,15 +13,13 @@ list( APPEND library_source_files
 
 # List of library include directories.
 list( APPEND library_include_directories
-             ${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS} )
+             ${FLEET_PROVISIONING_INCLUDE_PUBLIC_DIRS}
+             "${CMAKE_CURRENT_LIST_DIR}/../include" )
 
 # Create a target for building library.
 create_library_target( ${library_target_name}
                        "${library_source_files}"
                        "${library_include_directories}" )
-
-# Build Fleet Provisioning library without requiring config file.
-target_compile_definitions( ${library_target_name} PUBLIC FLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG=1 )
 
 # =========================== Test Binary ==============================
 


### PR DESCRIPTION
Fix library failing to build with logging enabled.
Additionally fix warnings in logging macro calls and enable logging in testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
