### PR TITLE
Fix broken MISRA link

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -1,7 +1,7 @@
 # MISRA Compliance
 
 The Fleet Provisioning Client Library files conform to the
-[MISRA C:2012](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx)
+[MISRA C:2012](https://www.misra.org.uk)
 guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
 Deviations from the MISRA standard are listed below:
 


### PR DESCRIPTION
A link in MISRA.md pointed to a page that no longer exists. This changes the link to point to the main page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
