### PR TITLE
Remove client wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## v1.0.0 (August 2021)
 
-This is the first release of the AWS IoT Fleet Provisioning Client Library.
+This is the first release of the AWS IoT Fleet Provisioning Library.

--- a/MISRA.md
+++ b/MISRA.md
@@ -1,9 +1,9 @@
 # MISRA Compliance
 
-The Fleet Provisioning Client Library files conform to the
-[MISRA C:2012](https://www.misra.org.uk)
-guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
-Deviations from the MISRA standard are listed below:
+The Fleet Provisioning Library files conform to the [MISRA
+C:2012](https://www.misra.org.uk) guidelines, with some noted exceptions.
+Compliance is checked with Coverity static analysis. Deviations from the MISRA
+standard are listed below:
 
 ### Ignored by [Coverity Configuration](tools/coverity/misra.config)
 | Deviation | Category | Justification |

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ The Fleet Provisioning library enables you to provision IoT devices without
 device certificates using the [AWS IoT Fleet Provisioning Service][a1]. For an
 overview of provisioning options available, see [Device provisioning][a2]. This
 library has no dependencies on any additional libraries other than the standard
-C library, and therefore, can be used with any MQTT client library. This library
-is distributed under the [MIT Open Source License][a3].
+C library, and therefore, can be used with any MQTT library. This library is
+distributed under the [MIT Open Source License][a3].
 
 [a1]: https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html
 [a2]: https://docs.aws.amazon.com/iot/latest/developerguide/iot-provision.html
@@ -29,9 +29,9 @@ See memory requirements for this library [here][a9].
 
 [a9]: ./docs/doxygen/include/size_table.md
 
-## AWS IoT Fleet Provisioning Client Config File
+## AWS IoT Fleet Provisioning Library Config File
 
-The AWS IoT Fleet Provisioning Client Library exposes build configuration
+The AWS IoT Fleet Provisioning Library exposes build configuration
 macros that are required for building the library. A list of all the
 configurations and their default values are defined in
 [fleet\_provisioning\_config\_defaults.h][b1]. To provide custom values for the
@@ -45,7 +45,7 @@ the library. To disable this requirement and build the library with default
 configuration values, provide `FLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG` as
 a compile time preprocessor macro.
 
-**Thus, the Fleet Provisioning client library can be built by either**:
+**Thus, the Fleet Provisioning library can be built by either**:
 
 * Defining a `fleet_provisioning_config.h` file in the application, and adding
   it to the include directories list of the library.
@@ -59,15 +59,15 @@ a compile time preprocessor macro.
 
 The [fleetprovisioningFilePaths.cmake][c1] file contains the information of all
 source files and the header include paths required to build the Fleet
-Provisioning client library.
+Provisioning library.
 
 [c1]: fleetprovisioningFilePaths.cmake
 
 As mentioned in the previous section, either a custom config file (i.e.
 `fleet_provisioning_config.h`) or `FLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG`
-macro needs to be provided to build the Fleet Provisioning client library.
+macro needs to be provided to build the Fleet Provisioning library.
 
-For a CMake example of building the Fleet Provisioning client library with the
+For a CMake example of building the Fleet Provisioning library with the
 `fleetprovisioningFilePaths.cmake` file, refer to the `coverity_analysis`
 library target in [test/CMakeLists.txt][c2] file.
 
@@ -99,7 +99,7 @@ library target in [test/CMakeLists.txt][c2] file.
 ## Reference examples
 
 The [AWS IoT Embedded C-SDK repository][e1] contains a demo showing the use of
-the AWS IoT Fleet Provisioning Client Library on a POSIX platform [here][e2].
+the AWS IoT Fleet Provisioning Library on a POSIX platform [here][e2].
 
 [e1]: https://github.com/aws/aws-iot-device-sdk-embedded-C
 [e2]: https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main/demos/fleet_provisioning/fleet_provisioning_with_csr

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # AWS IoT Fleet Provisioning Library
 
 The Fleet Provisioning library enables you to provision IoT devices without
-device certificates using the [AWS IoT Fleet Provisioning Service][a1]. For an
-overview of provisioning options available, see [Device provisioning][a2]. This
-library has no dependencies on any additional libraries other than the standard
-C library, and therefore, can be used with any MQTT library. This library is
-distributed under the [MIT Open Source License][a3].
+device certificates using the [Fleet Provisioning feature of AWS IoT Core][a1].
+For an overview of provisioning options available, see [Device
+provisioning][a2]. This library has no dependencies on any additional libraries
+other than the standard C library, and therefore, can be used with any MQTT
+library. This library is distributed under the [MIT Open Source License][a3].
 
 [a1]: https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html
 [a2]: https://docs.aws.amazon.com/iot/latest/developerguide/iot-provision.html

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         = "v1.0.0"
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "AWS IoT Fleet Provisioning Client Library"
+PROJECT_BRIEF          = "AWS IoT Fleet Provisioning Library"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -1,7 +1,7 @@
 /**
 @mainpage Overview
 @anchor fleet_provisioning
-@brief AWS IoT Fleet Provisioning Client Library
+@brief AWS IoT Fleet Provisioning Library
 
 > By using AWS IoT fleet provisioning, AWS IoT can generate and securely deliver device certificates and private keys to your devices when they connect to AWS IoT for the first time. AWS IoT provides client certificates that are signed by the Amazon Root certificate authority (CA).
 <span style="float:right;margin-right:4em"> &mdash; <i>Description of Fleet Provisioning from AWS IoT documentation <https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html></i></span><br>
@@ -25,14 +25,14 @@ CreateKeysAndCertificate provides a new certificate and corresponding private
 key.
 
 @section fleet_provisioning_memory_requirements Memory Requirements
-@brief Memory requirements of the AWS IoT Fleet Provisioning Client Library.
+@brief Memory requirements of the AWS IoT Fleet Provisioning Library.
 
 @include{doc} size_table.md
  */
 
 /**
 @page fleet_provisioning_design Design
-AWS IoT Fleet Provisioning Client Library Design
+AWS IoT Fleet Provisioning Library Design
 
 The AWS IoT Fleet Provisioning library provides macros and functions to
 assemble and parse MQTT topic strings reserved for the Fleet Provisioning
@@ -48,7 +48,7 @@ interact with the AWS IoT Fleet Provisioning APIs.
 
 /**
 @page fleet_provisioning_config Configurations
-@brief Configurations of the AWS IoT Fleet Provisioning Client Library.
+@brief Configurations of the AWS IoT Fleet Provisioning Library.
 <!-- @par configpagestyle allows the @section titles to be styled according to
      style.css -->
 @par configpagestyle
@@ -75,7 +75,7 @@ compiler option such as -D in gcc.
 
 /**
 @page fleet_provisioning_functions Functions
-@brief Primary functions of the AWS IoT Fleet Provisioning Client Library:<br><br>
+@brief Primary functions of the AWS IoT Fleet Provisioning Library:<br><br>
 @subpage fleet_provisioning_getregisterthingtopic_function <br>
 @subpage fleet_provisioning_matchtopic_function <br>
 
@@ -92,10 +92,10 @@ compiler option such as -D in gcc.
      past versions with "^^" newlines within the alias definition. -->
 /**
 @defgroup fleet_provisioning_enum_types Enumerated Types
-@brief Enumerated types of the AWS IoT Fleet Provisioning Client Library
+@brief Enumerated types of the AWS IoT Fleet Provisioning Library
 */
 
 /**
 @defgroup fleet_provisioning_constants Constants
-@brief Constants defined in the AWS IoT Fleet Provisioning Client Library
+@brief Constants defined in the AWS IoT Fleet Provisioning Library
 */

--- a/docs/doxygen/porting.dox
+++ b/docs/doxygen/porting.dox
@@ -1,6 +1,6 @@
 /**
 @page fleet_provisioning_porting Porting Guide
-@brief Guide for porting the AWS IoT Fleet Provisioning Client Library to a new
+@brief Guide for porting the AWS IoT Fleet Provisioning Library to a new
 platform.
 
 @section fleet_provisioning_porting_config Configuration Macros
@@ -18,8 +18,8 @@ The following optional logging macros are used throughout the library:
 @note Regardless of whether the above macros are defined in
 `fleet_provisioning_config.h` or passed as compiler options, by default the
 `fleet_provisioning_config.h` file is needed to build the AWS IoT Fleet
-Provisioning Client Library. To disable this requirement and build the library
-with default configuration values, provide
+Provisioning Library. To disable this requirement and build the library with
+default configuration values, provide
 `FLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG` as a compile time preprocessor
 macro.
  */

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 name: "Fleet-Provisioning-for-AWS-IoT-embedded-sdk"
 version: "v1.0.0"
 description: |
-  "Client library for using the AWS IoT Fleet Provisioning service on embedded devices.\n"
+  "Library for using the Fleet Provisioning feature of AWS IoT Core on embedded devices.\n"
 license: "MIT"

--- a/source/fleet_provisioning.c
+++ b/source/fleet_provisioning.c
@@ -1,5 +1,5 @@
 /*
- * AWS IoT Fleet Provisioning Client v1.0.0
+ * AWS IoT Fleet Provisioning v1.0.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,7 +22,7 @@
 
 /**
  * @file fleet_provisioning.c
- * @brief Implementation of the AWS IoT Fleet Provisioning Client Library.
+ * @brief Implementation of the AWS IoT Fleet Provisioning Library.
  */
 
 /* Standard includes. */

--- a/source/include/fleet_provisioning.h
+++ b/source/include/fleet_provisioning.h
@@ -1,5 +1,5 @@
 /*
- * AWS IoT Fleet Provisioning Client v1.0.0
+ * AWS IoT Fleet Provisioning v1.0.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,7 +22,7 @@
 
 /**
  * @file fleet_provisioning.h
- * @brief Interface for the AWS IoT Fleet Provisioning Client Library.
+ * @brief Interface for the AWS IoT Fleet Provisioning Library.
  */
 
 #ifndef FLEET_PROVISIONING_H_
@@ -634,7 +634,7 @@ typedef enum
  * {
  *      // The buffer pTopicBuffer contains the topic string of length
  *      // topicLength for getting a response for an accepted JSON RegisterThing
- *      // request. Subscribe to this topic using an MQTT client of your choice.
+ *      // request. Subscribe to this topic using an MQTT library of your choice.
  * }
  * @endcode
  */
@@ -676,7 +676,7 @@ FleetProvisioningStatus_t FleetProvisioning_GetRegisterThingTopic( char * pTopic
  *
  * // pTopic and topicLength are the topic string and length of the topic on
  * // which the publish message is received. These are usually provided by the
- * // MQTT client used.
+ * // MQTT library used.
  * status = FleetProvisioning_MatchTopic( pTopic
  *                                        topicLength,
  *                                        &( api ) );

--- a/source/include/fleet_provisioning_config_defaults.h
+++ b/source/include/fleet_provisioning_config_defaults.h
@@ -1,5 +1,5 @@
 /*
- * AWS IoT Fleet Provisioning Client v1.0.0
+ * AWS IoT Fleet Provisioning v1.0.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/source/include/fleet_provisioning_config_defaults.h
+++ b/source/include/fleet_provisioning_config_defaults.h
@@ -22,7 +22,7 @@
 
 /**
  * @file fleet_provisioning_config_defaults.h
- * @brief Default config values for the AWS IoT Fleet Provisioning Client Library.
+ * @brief Default config values for the AWS IoT Fleet Provisioning Library.
  */
 
 #ifndef FLEET_PROVISIONING_CONFIG_DEFAULTS_H_
@@ -32,11 +32,11 @@
  * Doxygen documentation only. */
 
 /**
- * @brief Define this macro to build the AWS IoT Fleet Provisioning Client
- * Library without the custom config file fleet_provisioning_config.h.
+ * @brief Define this macro to build the AWS IoT Fleet Provisioning Library
+ * without the custom config file fleet_provisioning_config.h.
  *
- * Without the custom config, the the AWS IoT Fleet Provisioning Client Library
- * builds with default values of config macros defined in the
+ * Without the custom config, the the AWS IoT Fleet Provisioning Library builds
+ * with default values of config macros defined in the
  * fleet_provisioning_config_defaults.h file.
  *
  * If a custom config file is provided, then
@@ -51,85 +51,80 @@
 #endif
 
 /**
- * @brief Macro used in the Fleet Provisioning client library to log error
- * messages.
+ * @brief Macro used in the Fleet Provisioning library to log error messages.
  *
  * To enable error logging, this macro should be mapped to an
  * application-specific logging implementation.
  *
- * @note This logging macro is called in the Fleet Provisioning client library
- * with parameters wrapped in double parentheses to be ISO C89/C90 standard
+ * @note This logging macro is called in the Fleet Provisioning library with
+ * parameters wrapped in double parentheses to be ISO C89/C90 standard
  * compliant. For a reference POSIX implementation of the logging macros, refer
  * to the fleet_provisioning_config.h file, and the logging-stack in demos
  * folder of the [AWS IoT Embedded C SDK
  * repository](https://github.com/aws/aws-iot-device-sdk-embedded-C).
  *
  * <b>Default value</b>: Error logs are turned off, and no code is generated for
- * calls to the macro in the Fleet Provisioning client library on compilation.
+ * calls to the macro in the Fleet Provisioning library on compilation.
  */
 #ifndef LogError
     #define LogError( message )
 #endif
 
 /**
- * @brief Macro used in the Fleet Provisioning client library to log warning
- * messages.
+ * @brief Macro used in the Fleet Provisioning library to log warning messages.
  *
  * To enable warning logging, this macro should be mapped to an
  * application-specific logging implementation.
  *
- * @note This logging macro is called in the Fleet Provisioning client library
- * with parameters wrapped in double parentheses to be ISO C89/C90 standard
+ * @note This logging macro is called in the Fleet Provisioning library with
+ * parameters wrapped in double parentheses to be ISO C89/C90 standard
  * compliant. For a reference POSIX implementation of the logging macros, refer
  * to the fleet_provisioning_config.h file, and the logging-stack in demos
  * folder of the [AWS IoT Embedded C SDK
  * repository](https://github.com/aws/aws-iot-device-sdk-embedded-C).
  *
  * <b>Default value</b>: Warning logs are turned off, and no code is generated
- * for calls to the macro in the Fleet Provisioning client library on
- * compilation.
+ * for calls to the macro in the Fleet Provisioning library on compilation.
  */
 #ifndef LogWarn
     #define LogWarn( message )
 #endif
 
 /**
- * @brief Macro used in the Fleet Provisioning client library to log info
- * messages.
+ * @brief Macro used in the Fleet Provisioning library to log info messages.
  *
  * To enable info logging, this macro should be mapped to an
  * application-specific logging implementation.
  *
- * @note This logging macro is called in the Fleet Provisioning client library
- * with parameters wrapped in double parentheses to be ISO C89/C90 standard
+ * @note This logging macro is called in the Fleet Provisioning library with
+ * parameters wrapped in double parentheses to be ISO C89/C90 standard
  * compliant. For a reference POSIX implementation of the logging macros, refer
  * to the fleet_provisioning_config.h file, and the logging-stack in demos
  * folder of the [AWS IoT Embedded C SDK
  * repository](https://github.com/aws/aws-iot-device-sdk-embedded-C).
  *
  * <b>Default value</b>: Info logs are turned off, and no code is generated for
- * calls to the macro in the Fleet Provisioning client library on compilation.
+ * calls to the macro in the Fleet Provisioning library on compilation.
  */
 #ifndef LogInfo
     #define LogInfo( message )
 #endif
 
 /**
- * @brief Macro used in the Fleet Provisioning client library to log debug
- * messages.
+ * @brief Macro used in the Fleet Provisioning library to log debug messages.
  *
  * To enable debug logging, this macro should be mapped to an
  * application-specific logging implementation.
  *
- * @note This logging macro is called in the Fleet Provisioning client library
- * with parameters wrapped in double parentheses to be ISO C89/C90 standard
+ * @note This logging macro is called in the Fleet Provisioning library with
+ * parameters wrapped in double parentheses to be ISO C89/C90 standard
  * compliant. For a reference POSIX implementation of the logging macros, refer
  * to the fleet_provisioning_config.h file, and the logging-stack in demos
  * folder of the [AWS IoT Embedded C SDK
  * repository](https://github.com/aws/aws-iot-device-sdk-embedded-C).
  *
  * <b>Default value</b>: Debug logs are turned off, and no code is generated for
- * calls to the macro in the Fleet Provisioning client library on compilation.
+ * calls to the macro in the Fleet Provisioning library on compilation.
  */
 #ifndef LogDebug
     #define LogDebug( message )

--- a/test/cbmc/proofs/FleetProvisioning_GetRegisterThingTopic/FleetProvisioning_GetRegisterThingTopic_harness.c
+++ b/test/cbmc/proofs/FleetProvisioning_GetRegisterThingTopic/FleetProvisioning_GetRegisterThingTopic_harness.c
@@ -1,5 +1,5 @@
 /*
- * AWS IoT Fleet Provisioning Client v1.0.0
+ * AWS IoT Fleet Provisioning v1.0.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/test/cbmc/proofs/FleetProvisioning_MatchTopic/FleetProvisioning_MatchTopic_harness.c
+++ b/test/cbmc/proofs/FleetProvisioning_MatchTopic/FleetProvisioning_MatchTopic_harness.c
@@ -1,5 +1,5 @@
 /*
- * AWS IoT Fleet Provisioning Client v1.0.0
+ * AWS IoT Fleet Provisioning v1.0.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/test/include/fleet_provisioning_config.h
+++ b/test/include/fleet_provisioning_config.h
@@ -1,5 +1,5 @@
 /*
- * AWS IoT Fleet Provisioning Client v1.0.0
+ * AWS IoT Fleet Provisioning v1.0.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,7 +22,7 @@
 
 /**
  * @file fleet_provisioning_config.h
- * @brief Config values for testing the AWS IoT Fleet Provisioning Client Library.
+ * @brief Config values for testing the AWS IoT Fleet Provisioning Library.
  */
 
 #ifndef FLEET_PROVISIONING_CONFIG_H_

--- a/test/unit-test/fleet_provisioning_utest.c
+++ b/test/unit-test/fleet_provisioning_utest.c
@@ -1,5 +1,5 @@
 /*
- * AWS IoT Fleet Provisioning Client v1.0.0
+ * AWS IoT Fleet Provisioning v1.0.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Remove use of "client" in documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
