### PR TITLE
Added doxygen-generation for new commits and release

### DIFF
--- a/.github/workflows/doxygen-generation.yml
+++ b/.github/workflows/doxygen-generation.yml
@@ -1,0 +1,11 @@
+name: Doxygen Generation
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  doxygen-generation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Doxygen generation
+        uses: FreeRTOS/CI-CD-Github-Actions/doxygen-generation@main

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -112,3 +112,7 @@ jobs:
           asset_path: ./Fleet-Provisioning-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip
           asset_name: Fleet-Provisioning-for-AWS-IoT-embedded-sdk-${{ github.event.inputs.version_number }}.zip
           asset_content_type: application/zip
+      - name: Doxygen generation
+        uses: FreeRTOS/CI-CD-Github-Actions/doxygen-generation@main
+        with:
+          ref: ${{ github.event.inputs.version_number }}


### PR DESCRIPTION
*Description of changes:*
This PR adds a workflow to auto generate doxygen and push to gh-pages branch on new commits. It also adds a step in release workflow to generate doxygen and push to gh-pages. Both uses [doxygen-generation](https://github.com/FreeRTOS/CI-CD-Github-Actions/tree/main/doxygen-generation) action from CI-CD-Github-Actions.

*Test*
Tested the actions on my fork https://github.com/tianmc1/Fleet-Provisioning-for-AWS-IoT-embedded-sdk/actions/runs/1317144734 and https://github.com/tianmc1/Fleet-Provisioning-for-AWS-IoT-embedded-sdk/actions/runs/1317404732.