### PR TITLE
Fix warnings with -Wall -Wextra enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
         with:
           coverage-file: ./build/coverage.info
+          branch-coverage-min: 100
+          line-coverage-min: 100
   build-with-default-config:
     runs-on: ubuntu-latest
     steps:

--- a/source/fleet_provisioning.c
+++ b/source/fleet_provisioning.c
@@ -286,9 +286,7 @@ static FleetProvisioningStatus_t GetRegisterThingTopicCheckParams( const char * 
     FleetProvisioningStatus_t ret = FleetProvisioningError;
 
     if( ( pTopicBuffer == NULL ) ||
-        ( format < FleetProvisioningJson ) ||
         ( format > FleetProvisioningCbor ) ||
-        ( topic < FleetProvisioningPublish ) ||
         ( topic > FleetProvisioningRejected ) ||
         ( pTemplateName == NULL ) ||
         ( templateNameLength == 0U ) ||

--- a/source/fleet_provisioning.c
+++ b/source/fleet_provisioning.c
@@ -286,8 +286,8 @@ static FleetProvisioningStatus_t GetRegisterThingTopicCheckParams( const char * 
     FleetProvisioningStatus_t ret = FleetProvisioningError;
 
     if( ( pTopicBuffer == NULL ) ||
-        !( ( format >= FleetProvisioningJson ) && ( format <= FleetProvisioningCbor ) ) ||
-        !( ( topic >= FleetProvisioningPublish ) && ( topic <= FleetProvisioningRejected ) ) ||
+        ( ( format != FleetProvisioningJson ) && ( format != FleetProvisioningCbor ) ) ||
+        ( ( topic != FleetProvisioningPublish ) && ( topic != FleetProvisioningAccepted ) && ( topic != FleetProvisioningRejected ) ) ||
         ( pTemplateName == NULL ) ||
         ( templateNameLength == 0U ) ||
         ( templateNameLength > FP_TEMPLATENAME_MAX_LENGTH ) ||

--- a/source/fleet_provisioning.c
+++ b/source/fleet_provisioning.c
@@ -286,8 +286,8 @@ static FleetProvisioningStatus_t GetRegisterThingTopicCheckParams( const char * 
     FleetProvisioningStatus_t ret = FleetProvisioningError;
 
     if( ( pTopicBuffer == NULL ) ||
-        ( format > FleetProvisioningCbor ) ||
-        ( topic > FleetProvisioningRejected ) ||
+        !( ( format >= FleetProvisioningJson ) && ( format <= FleetProvisioningCbor ) ) ||
+        !( ( topic >= FleetProvisioningPublish ) && ( topic <= FleetProvisioningRejected ) ) ||
         ( pTemplateName == NULL ) ||
         ( templateNameLength == 0U ) ||
         ( templateNameLength > FP_TEMPLATENAME_MAX_LENGTH ) ||

--- a/test/cbmc/proofs/FleetProvisioning_GetRegisterThingTopic/FleetProvisioning_GetRegisterThingTopic_harness.c
+++ b/test/cbmc/proofs/FleetProvisioning_GetRegisterThingTopic/FleetProvisioning_GetRegisterThingTopic_harness.c
@@ -47,7 +47,7 @@ void harness()
     __CPROVER_assume( templateNameLength <= ( FP_TEMPLATENAME_MAX_LENGTH + 1 ) );
 
     /* Assume that format and topics are in valid enum range since library has
-    asserts to catch out of range cases. */
+     * asserts to catch out of range cases. */
     __CPROVER_assume( ( format >= FleetProvisioningJson ) && ( format <= FleetProvisioningCbor ) );
     __CPROVER_assume( ( topic >= FleetProvisioningPublish ) && ( topic <= FleetProvisioningRejected ) );
 

--- a/test/cbmc/proofs/FleetProvisioning_GetRegisterThingTopic/FleetProvisioning_GetRegisterThingTopic_harness.c
+++ b/test/cbmc/proofs/FleetProvisioning_GetRegisterThingTopic/FleetProvisioning_GetRegisterThingTopic_harness.c
@@ -46,11 +46,6 @@ void harness()
      * lengths as well. */
     __CPROVER_assume( templateNameLength <= ( FP_TEMPLATENAME_MAX_LENGTH + 1 ) );
 
-    /* Assume that format and topics are in valid enum range since library has
-     * asserts to catch out of range cases. */
-    __CPROVER_assume( ( format >= FleetProvisioningJson ) && ( format <= FleetProvisioningCbor ) );
-    __CPROVER_assume( ( topic >= FleetProvisioningPublish ) && ( topic <= FleetProvisioningRejected ) );
-
     pTopicBuffer = malloc( topicBufferLength );
     pTemplateName = malloc( templateNameLength );
     pOutLength = malloc( sizeof( *pOutLength ) );

--- a/test/cbmc/proofs/FleetProvisioning_GetRegisterThingTopic/FleetProvisioning_GetRegisterThingTopic_harness.c
+++ b/test/cbmc/proofs/FleetProvisioning_GetRegisterThingTopic/FleetProvisioning_GetRegisterThingTopic_harness.c
@@ -46,6 +46,11 @@ void harness()
      * lengths as well. */
     __CPROVER_assume( templateNameLength <= ( FP_TEMPLATENAME_MAX_LENGTH + 1 ) );
 
+    /* Assume that format and topics are in valid enum range since library has
+    asserts to catch out of range cases. */
+    __CPROVER_assume( ( format >= FleetProvisioningJson ) && ( format <= FleetProvisioningCbor ) );
+    __CPROVER_assume( ( topic >= FleetProvisioningPublish ) && ( topic <= FleetProvisioningRejected ) );
+
     pTopicBuffer = malloc( topicBufferLength );
     pTemplateName = malloc( templateNameLength );
     pOutLength = malloc( sizeof( *pOutLength ) );


### PR DESCRIPTION
*Issue #, if available:*

When library is compiled with `-Wextra` on ARM GCC compiler (`arm-none-eabi-gcc`) the following warnings are emitted:
```
(base) [δ:0s T:15:39:04]ubuntu@ip-172-31-69-236:~/Projects/Fleet-Provisioning-for-AWS-IoT-embedded-sdk$ arm-none-eabi-gcc -std=gnu99 -ggdb -DNDEBUG -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16 source/fleet_provisioning.c -c -I source/include -DFLEET_PROVISIONING_DO_NOT_USE_CUSTOM_CONFIG -Wall -Wextra
source/fleet_provisioning.c: In function 'GetRegisterThingTopicCheckParams':
source/fleet_provisioning.c:289:18: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  289 |         ( format < FleetProvisioningJson ) ||
      |                  ^
source/fleet_provisioning.c:291:17: warning: comparison is always false due to limited range of data type [-Wtype-limits]
  291 |         ( topic < FleetProvisioningPublish ) ||
      |                 ^
```

*Description of changes:*


This PR fixes that by removing the `( format < FleetProvisioningJson )` and `( topic < FleetProvisioningPublish )` checks as they are always false. `format` and `topic` are of the type `FleetProvisioningFormat_t` and `FleetProvisioningApiTopics_t`, thus wont be less than the minimum values `FleetProvisioningJson` and `FleetProvisioningPublish` respectively.

- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
