### PR TITLE
Use CBMC version 5.95.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,8 @@ jobs:
     steps:
       - name: Set up CBMC runner
         uses: FreeRTOS/CI-CD-Github-Actions/set_up_cbmc_runner@main
+        with:
+          cbmc_version: "5.95.1"
       - name: Run CBMC
         uses: FreeRTOS/CI-CD-Github-Actions/run_cbmc@main
         with:


### PR DESCRIPTION
*Description of changes:*
The upcoming CBMC version 6 release includes changes that may affect existing proofs. This PR will make sure that
Fleet-Provisioning-for-AWS-IoT-embedded-sdk PRs are not negatively impacted by this release. After releasing CBMC version 6 we will issue a follow-up PR that will return
Fleet-Provisioning-for-AWS-IoT-embedded-sdk to using CBMC's latest release, and will include any changes to proofs that may be necessary to support the new version.



By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
